### PR TITLE
fix: missing `oneway` keyword in syntax file

### DIFF
--- a/syntaxes/thrift.tmLanguage
+++ b/syntaxes/thrift.tmLanguage
@@ -609,12 +609,12 @@
 								<dict>
 									<key>begin</key>
 									<string>(?x)(?&lt;!\S)
-											(async(?!\S))?\s*
+											(oneway(?!\S))?\s*
 											(?&lt;ft&gt;
 												map\s*&lt;\s*\g&lt;ft&gt;\s*,\s*\g&lt;ft&gt;\s*&gt; |
 												set\s*&lt;\s*\g&lt;ft&gt;\s*&gt; |
 												list\s*&lt;\s*\g&lt;ft&gt;\s*&gt;\s*(cpp_type(?!\S))? |
-												(?!async\b)[a-zA-Z_][\w.]*
+												(?!oneway\b)[a-zA-Z_][\w.]*
 											)\s*
 											(?:
 												(?&lt;!\S)([a-zA-Z_][\w.]*)\s*(?![^\s(])
@@ -624,7 +624,7 @@
 										<key>1</key>
 										<dict>
 											<key>name</key>
-											<string>keyword.other.async.thrift</string>
+											<string>keyword.other.oneway.thrift</string>
 										</dict>
 										<key>2</key>
 										<dict>


### PR DESCRIPTION
原本的 `thrift.tmLanguage` 中不支持 `oneway` 关键字，本该是 `oneway` 的地方出现的是 `async`。

可能是历史原因？查了一下，[Thrift 白皮书](https://thrift.apache.org/static/files/thrift-20070401.pdf)中用的是 `async`；但即使在 0.2.0 版，用的也是 `oneway` 而不是 `async`。

总之我只是把 `thrift.tmLanguage` 中的 `async` 改成了 `oneway`。