### PR TITLE
fix: missing language configuration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "id": "thrift",
         "extensions": [
           ".thrift"
-        ]
+        ],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [


### PR DESCRIPTION
package.json 好像漏了这么一行，导致切换注释、匹配括号等功能没法使用。